### PR TITLE
Fix opening project and rename support

### DIFF
--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Plus, Calendar, MoreVertical } from "lucide-react";
 import { Header } from "@/components/Header";
@@ -16,6 +16,21 @@ interface Project {
 export default function Dashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  useEffect(() => {
+    const saved = localStorage.getItem("projects");
+    if (saved) {
+      try {
+        setProjects(JSON.parse(saved) as Project[]);
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("projects", JSON.stringify(projects));
+  }, [projects]);
+
   const handleCreateProject = () => {
     const newProject: Project = {
       id: Date.now(),
@@ -27,6 +42,14 @@ export default function Dashboard() {
         "https://cdn.builder.io/api/v1/image/assets/TEMP/08011607c6a0e23896437034e591fad03111f03b?width=400",
     };
     setProjects([newProject, ...projects]);
+  };
+
+  const handleRenameProject = (id: number) => {
+    const name = prompt("Project name?");
+    if (!name) return;
+    setProjects((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, title: name } : p)),
+    );
   };
 
   return (
@@ -67,7 +90,10 @@ export default function Dashboard() {
                   <h3 className="text-lg font-bold text-white truncate">
                     {project.title}
                   </h3>
-                  <button className="text-gray-400 hover:text-white p-1">
+                  <button
+                    onClick={() => handleRenameProject(project.id)}
+                    className="text-gray-400 hover:text-white p-1"
+                  >
                     <MoreVertical className="w-4 h-4" />
                   </button>
                 </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -9,11 +9,10 @@ import { fetchScenes, addScene } from "@/lib/api";
 
 export default function Index() {
   const [scenes, setScenes] = useState<Scene[]>([]);
-  const [selectedScene, setSelectedScene] = useState<number>(1);
+  const [selectedScene, setSelectedScene] = useState<number | null>(null);
   const [showFullView, setShowFullView] = useState<boolean>(false);
 
-  const currentScene =
-    scenes.find((scene) => scene.id === selectedScene) || scenes[0];
+  const currentScene = scenes.find((scene) => scene.id === selectedScene) || null;
 
   useEffect(() => {
     fetchScenes().then((data) => {
@@ -99,7 +98,18 @@ export default function Index() {
 
           {/* Scene Content */}
           <div className="flex-1 overflow-y-auto">
-            {showFullView ? (
+            {scenes.length === 0 ? (
+              <div className="max-w-4xl mx-auto px-4 lg:px-6 py-6 text-center">
+                <p className="text-gray-400 mb-4">No scenes yet</p>
+                <button
+                  onClick={handleAddScene}
+                  className="flex items-center gap-2 px-6 py-3 bg-dark-card border border-gray-600 text-white text-sm font-medium rounded-xl hover:bg-gray-700 transition-colors"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add First Scene
+                </button>
+              </div>
+            ) : showFullView ? (
               // Full vertical view of all scenes
               <div className="max-w-4xl mx-auto px-4 lg:px-6 py-6 space-y-12">
                 {scenes.map((scene, idx) => (


### PR DESCRIPTION
## Summary
- handle local project persistence and renaming
- prevent blank screen for projects with no scenes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686974258c50832992737796cad580d8