### PR TITLE
Fix inline project rename, dark PDF preview

### DIFF
--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,37 +1,93 @@
 import { Scene, CreateScenePayload } from '@shared/api';
 
+function readLocal(): Scene[] {
+  const raw = localStorage.getItem('scenes');
+  try {
+    return raw ? (JSON.parse(raw) as Scene[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(scenes: Scene[]) {
+  localStorage.setItem('scenes', JSON.stringify(scenes));
+}
+
 export async function fetchScenes(): Promise<Scene[]> {
-  const res = await fetch('/api/scenes');
-  if (!res.ok) throw new Error('Failed to load scenes');
-  return res.json();
+  try {
+    const res = await fetch('/api/scenes');
+    if (!res.ok) throw new Error('Failed to load scenes');
+    const data = await res.json();
+    writeLocal(data);
+    return data;
+  } catch {
+    return readLocal();
+  }
 }
 
 export async function addScene(payload: CreateScenePayload): Promise<Scene> {
-  const res = await fetch('/api/scenes', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) throw new Error('Failed to create scene');
-  return res.json();
+  try {
+    const res = await fetch('/api/scenes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error('Failed to create scene');
+    const created = await res.json();
+    const scenes = readLocal();
+    scenes.push(created);
+    writeLocal(scenes);
+    return created;
+  } catch {
+    const scenes = readLocal();
+    const newScene: Scene = { id: Date.now(), ...payload };
+    scenes.push(newScene);
+    writeLocal(scenes);
+    return newScene;
+  }
 }
 
 export async function updateScene(id: number, data: Partial<Scene>): Promise<Scene> {
-  const res = await fetch(`/api/scenes/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-  if (!res.ok) throw new Error('Failed to update scene');
-  return res.json();
+  try {
+    const res = await fetch(`/api/scenes/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error('Failed to update scene');
+    const updated = await res.json();
+    const scenes = readLocal().map((s) => (s.id === id ? updated : s));
+    writeLocal(scenes);
+    return updated;
+  } catch {
+    const scenes = readLocal();
+    const idx = scenes.findIndex((s) => s.id === id);
+    if (idx !== -1) {
+      scenes[idx] = { ...scenes[idx], ...data } as Scene;
+      writeLocal(scenes);
+      return scenes[idx];
+    }
+    throw new Error('Failed to update scene');
+  }
 }
 
 export async function deleteScene(id: number): Promise<void> {
-  await fetch(`/api/scenes/${id}`, { method: 'DELETE' });
+  try {
+    await fetch(`/api/scenes/${id}`, { method: 'DELETE' });
+    const scenes = readLocal().filter((s) => s.id !== id);
+    writeLocal(scenes);
+  } catch {
+    const scenes = readLocal().filter((s) => s.id !== id);
+    writeLocal(scenes);
+  }
 }
 
 export async function downloadPdf(): Promise<Blob> {
-  const res = await fetch('/api/pdf');
-  if (!res.ok) throw new Error('Failed to generate pdf');
-  return res.blob();
+  try {
+    const res = await fetch('/api/pdf');
+    if (!res.ok) throw new Error('Failed to generate pdf');
+    return await res.blob();
+  } catch (err) {
+    throw new Error('Failed to generate pdf');
+  }
 }

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -15,6 +15,8 @@ interface Project {
 
 export default function Dashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [titleDraft, setTitleDraft] = useState<string>('');
 
   useEffect(() => {
     const saved = localStorage.getItem("projects");
@@ -42,14 +44,26 @@ export default function Dashboard() {
         "https://cdn.builder.io/api/v1/image/assets/TEMP/08011607c6a0e23896437034e591fad03111f03b?width=400",
     };
     setProjects([newProject, ...projects]);
+    setEditingId(newProject.id);
+    setTitleDraft(newProject.title);
   };
 
   const handleRenameProject = (id: number) => {
-    const name = prompt("Project name?");
-    if (!name) return;
-    setProjects((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, title: name } : p)),
-    );
+    const project = projects.find((p) => p.id === id);
+    if (!project) return;
+    setEditingId(id);
+    setTitleDraft(project.title);
+  };
+
+  const commitRename = () => {
+    if (editingId === null) return;
+    const name = titleDraft.trim();
+    if (name) {
+      setProjects((prev) =>
+        prev.map((p) => (p.id === editingId ? { ...p, title: name } : p)),
+      );
+    }
+    setEditingId(null);
   };
 
   return (
@@ -87,9 +101,20 @@ export default function Dashboard() {
 
               <div className="p-4">
                 <div className="flex justify-between items-start mb-2">
-                  <h3 className="text-lg font-bold text-white truncate">
-                    {project.title}
-                  </h3>
+                  {editingId === project.id ? (
+                    <input
+                      autoFocus
+                      value={titleDraft}
+                      onChange={(e) => setTitleDraft(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => e.key === 'Enter' && commitRename()}
+                      className="bg-dark-lighter border border-gray-600 rounded px-2 py-1 text-sm text-white w-full mr-2"
+                    />
+                  ) : (
+                    <h3 className="text-lg font-bold text-white truncate">
+                      {project.title}
+                    </h3>
+                  )}
                   <button
                     onClick={() => handleRenameProject(project.id)}
                     className="text-gray-400 hover:text-white p-1"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -21,6 +21,10 @@ export default function Index() {
     });
   }, []);
 
+  useEffect(() => {
+    localStorage.setItem('scenes', JSON.stringify(scenes));
+  }, [scenes]);
+
   const handleExportPDF = () => {
     window.location.href = "/pdf-preview";
   };

--- a/client/pages/PDFPreview.tsx
+++ b/client/pages/PDFPreview.tsx
@@ -16,14 +16,19 @@ export default function PDFPreview() {
 
   const handleDownload = async () => {
     setIsDownloading(true);
-    const blob = await downloadPdf();
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "storyboard.pdf";
-    link.click();
-    URL.revokeObjectURL(url);
-    setIsDownloading(false);
+    try {
+      const blob = await downloadPdf();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'storyboard.pdf';
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert('Failed to generate PDF');
+    } finally {
+      setIsDownloading(false);
+    }
   };
 
   const handleBack = () => {
@@ -31,29 +36,29 @@ export default function PDFPreview() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 font-space-grotesk">
+    <div className="min-h-screen bg-dark font-space-grotesk">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 px-6 py-4">
+      <header className="bg-dark-card border-b border-gray-600 px-6 py-4">
         <div className="max-w-7xl mx-auto flex justify-between items-center">
           <div className="flex items-center gap-4">
             <button
               onClick={handleBack}
-              className="flex items-center gap-2 text-gray-600 hover:text-gray-800 transition-colors"
+              className="flex items-center gap-2 text-gray-300 hover:text-white transition-colors"
             >
               <ArrowLeft className="w-4 h-4" />
               Back to Project
             </button>
-            <div className="w-px h-6 bg-gray-300"></div>
+            <div className="w-px h-6 bg-gray-600"></div>
             <div className="flex items-center gap-2">
-              <FileText className="w-5 h-5 text-gray-600" />
-              <h1 className="text-xl font-bold text-gray-800">PDF Preview</h1>
+              <FileText className="w-5 h-5 text-gray-300" />
+              <h1 className="text-xl font-bold text-white">PDF Preview</h1>
             </div>
           </div>
 
           <button
             onClick={handleDownload}
             disabled={isDownloading}
-            className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700 disabled:bg-blue-400 transition-colors"
+            className="flex items-center gap-2 px-6 py-2 bg-brand-blue text-dark text-sm font-bold rounded-lg hover:bg-opacity-90 disabled:opacity-50 transition-colors"
           >
             <Download className="w-4 h-4" />
             {isDownloading ? "Generating..." : "Download PDF"}
@@ -64,14 +69,14 @@ export default function PDFPreview() {
       {/* PDF Preview Content */}
       <div className="max-w-4xl mx-auto px-6 py-8">
         {/* PDF Container */}
-        <div className="bg-white shadow-lg rounded-lg overflow-hidden">
+        <div className="bg-dark-card border border-gray-600 rounded-lg overflow-hidden">
           {/* PDF Header */}
-          <div className="bg-gray-800 text-white p-8 text-center">
+          <div className="bg-dark-lighter text-white p-8 text-center">
             <h1 className="text-3xl font-bold mb-2">
               Enchanted Forest Adventure
             </h1>
-            <p className="text-gray-300">Storyboard Presentation</p>
-            <div className="mt-4 text-sm text-gray-400">
+            <p className="text-gray-400">Storyboard Presentation</p>
+            <div className="mt-4 text-sm text-gray-500">
               Generated on {new Date().toLocaleDateString()}
             </div>
           </div>
@@ -81,9 +86,9 @@ export default function PDFPreview() {
             {scenes.map((scene, index) => (
               <div key={scene.id} className="page-break-inside-avoid">
                 {/* Scene Header */}
-                <div className="border-b border-gray-200 pb-4 mb-6">
-                  <h2 className="text-2xl font-bold text-gray-800 flex items-center gap-3">
-                    <span className="bg-blue-600 text-white w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold">
+                <div className="border-b border-gray-600 pb-4 mb-6">
+                  <h2 className="text-2xl font-bold text-white flex items-center gap-3">
+                    <span className="bg-brand-blue text-dark w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold">
                       {index + 1}
                     </span>
                     {scene.title}
@@ -94,10 +99,10 @@ export default function PDFPreview() {
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
                   {/* Scene Image */}
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-700 mb-3">
+                    <h3 className="text-lg font-semibold text-white mb-3">
                       Scene Visual
                     </h3>
-                    <div className="aspect-video bg-gray-100 rounded-lg overflow-hidden border">
+                    <div className="aspect-video bg-dark-lighter rounded-lg overflow-hidden border border-gray-600">
                       <img
                         src={scene.image}
                         alt={scene.title}
@@ -109,11 +114,11 @@ export default function PDFPreview() {
                   {/* Scene Details */}
                   <div className="space-y-6">
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-700 mb-3">
+                      <h3 className="text-lg font-semibold text-white mb-3">
                         Scene Details
                       </h3>
-                      <div className="p-4 bg-gray-50 rounded-lg border">
-                        <p className="text-sm text-gray-700 leading-relaxed">
+                      <div className="p-4 bg-dark-lighter rounded-lg border border-gray-600">
+                        <p className="text-sm text-gray-300 leading-relaxed">
                           {scene.details}
                         </p>
                       </div>
@@ -123,11 +128,11 @@ export default function PDFPreview() {
 
                 {/* Voiceover */}
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-700 mb-3">
+                  <h3 className="text-lg font-semibold text-white mb-3">
                     Voiceover Script
                   </h3>
-                  <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                    <p className="text-sm text-gray-800 leading-relaxed italic">
+                  <div className="p-4 bg-dark-lighter border border-gray-600 rounded-lg">
+                    <p className="text-sm text-gray-300 leading-relaxed italic">
                       {scene.voiceover}
                     </p>
                   </div>
@@ -135,18 +140,18 @@ export default function PDFPreview() {
 
                 {/* Separator for next scene */}
                 {index < scenes.length - 1 && (
-                  <div className="mt-12 border-t border-gray-300"></div>
+                  <div className="mt-12 border-t border-gray-600"></div>
                 )}
               </div>
             ))}
 
             {/* PDF Footer */}
-            <div className="mt-16 pt-8 border-t border-gray-200 text-center">
-              <div className="text-sm text-gray-500 space-y-2">
+            <div className="mt-16 pt-8 border-t border-gray-600 text-center">
+              <div className="text-sm text-gray-400 space-y-2">
                 <p>Total Scenes: {scenes.length}</p>
                 <p>
-                  Designed with love by{" "}
-                  <span className="text-blue-600 font-medium">
+                  Designed with love by{' '}
+                  <span className="text-brand-blue font-medium">
                     yantramayaa designs
                   </span>
                 </p>
@@ -157,13 +162,13 @@ export default function PDFPreview() {
 
         {/* Download Section */}
         <div className="mt-8 text-center">
-          <p className="text-gray-600 mb-4">
+          <p className="text-gray-400 mb-4">
             This is a preview of how your PDF will look when exported.
           </p>
           <button
             onClick={handleDownload}
             disabled={isDownloading}
-            className="inline-flex items-center gap-2 px-8 py-3 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700 disabled:bg-blue-400 transition-colors"
+            className="inline-flex items-center gap-2 px-8 py-3 bg-brand-blue text-dark text-sm font-bold rounded-lg hover:bg-opacity-90 disabled:opacity-50 transition-colors"
           >
             <Download className="w-5 h-5" />
             {isDownloading ? "Generating PDF..." : "Download PDF"}


### PR DESCRIPTION
## Summary
- store scenes locally when backend is unreachable and use them when adding/updating/deleting scenes
- allow editing project titles inline on dashboard and start editing on project creation
- persist scenes to localStorage on project page
- switch PDF preview page to dark theme and handle download errors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869781a74d483299d6989895e6f9fc2