### PR TITLE
Fix serverless build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "express": "^4.18.2",
         "pdfkit": "^0.17.1",
+        "serverless-http": "^3.2.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -73,7 +74,6 @@
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
-        "serverless-http": "^3.2.0",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss": "^3.4.11",
@@ -7149,7 +7149,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
       "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "pdfkit": "^0.17.1",
+    "serverless-http": "^3.2.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -87,7 +88,6 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
-    "serverless-http": "^3.2.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.11",

--- a/server/routes/scenes.ts
+++ b/server/routes/scenes.ts
@@ -1,8 +1,10 @@
 import { RequestHandler } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { Scene, CreateScenePayload } from "@shared/api";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dataPath = path.join(__dirname, "../data/scenes.json");
 
 function readScenes(): Scene[] {


### PR DESCRIPTION
## Summary
- ensure serverless-http is installed in production env
- fix __dirname usage for ESM server

## Testing
- `npm test`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6869a0dfb3e48329a59ef3fdc4d5c5bc