### PR TITLE
Fix PDF preview header and add replace image dialog

### DIFF
--- a/client/components/SceneCard.tsx
+++ b/client/components/SceneCard.tsx
@@ -1,7 +1,16 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { updateScene } from "@/lib/api";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 interface Scene {
   id: number;
@@ -26,12 +35,25 @@ export function SceneCard({
   onUpdate,
   index,
 }: SceneCardProps) {
-  const handleReplaceImage = async () => {
-    const url = prompt("New image URL", scene.image);
-    if (!url) return;
-    const updated = await updateScene(scene.id, { image: url });
+  const [open, setOpen] = useState(false);
+  const [newImage, setNewImage] = useState(scene.image);
+
+  const handleSaveImage = async () => {
+    if (!newImage) return;
+    const updated = await updateScene(scene.id, { image: newImage });
     scene.image = updated.image;
     onUpdate?.(updated);
+    setOpen(false);
+  };
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setNewImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
   };
  
   const initialTitle =
@@ -87,12 +109,36 @@ export function SceneCard({
             alt={scene.title}
             className="w-full h-full object-cover"
           />
-          <button
-            onClick={handleReplaceImage}
-            className="absolute top-2 right-2 bg-dark-card text-white text-xs px-2 py-1 rounded"
-          >
-            Replace Image
-          </button>
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <button
+                className="absolute top-2 right-2 bg-dark-card text-white text-xs px-2 py-1 rounded"
+              >
+                Replace Image
+              </button>
+            </DialogTrigger>
+            <DialogContent className="bg-dark-card border border-gray-600 text-white">
+              <DialogHeader>
+                <DialogTitle>Replace Image</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <input
+                  type="text"
+                  className="w-full bg-dark-lighter border border-gray-600 rounded px-2 py-1"
+                  placeholder="Image URL"
+                  value={newImage}
+                  onChange={(e) => setNewImage(e.target.value)}
+                />
+                <input type="file" accept="image/*" onChange={handleFile} />
+              </div>
+              <DialogFooter className="mt-4">
+                <Button variant="secondary" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSaveImage}>Save</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
 
         <div className="grid md:grid-cols-2 gap-6">
@@ -144,12 +190,36 @@ export function SceneCard({
           alt={scene.title}
           className="w-full h-full object-cover"
         />
-        <button
-          onClick={handleReplaceImage}
-          className="absolute top-2 right-2 bg-dark-card text-white text-xs px-2 py-1 rounded"
-        >
-          Replace Image
-        </button>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <button
+              className="absolute top-2 right-2 bg-dark-card text-white text-xs px-2 py-1 rounded"
+            >
+              Replace Image
+            </button>
+          </DialogTrigger>
+          <DialogContent className="bg-dark-card border border-gray-600 text-white">
+            <DialogHeader>
+              <DialogTitle>Replace Image</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <input
+                type="text"
+                className="w-full bg-dark-lighter border border-gray-600 rounded px-2 py-1"
+                placeholder="Image URL"
+                value={newImage}
+                onChange={(e) => setNewImage(e.target.value)}
+              />
+              <input type="file" accept="image/*" onChange={handleFile} />
+            </div>
+            <DialogFooter className="mt-4">
+              <Button variant="secondary" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSaveImage}>Save</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="space-y-6">

--- a/client/pages/PDFPreview.tsx
+++ b/client/pages/PDFPreview.tsx
@@ -8,6 +8,7 @@ export default function PDFPreview() {
   const navigate = useNavigate();
   const [isDownloading, setIsDownloading] = useState(false);
   const [scenes, setScenes] = useState<Scene[]>([]);
+  const [remarks, setRemarks] = useState("");
 
   useEffect(() => {
     fetchScenes().then(setScenes);
@@ -70,14 +71,14 @@ export default function PDFPreview() {
         {/* PDF Container */}
         <div className="bg-dark-card border border-gray-600 rounded-lg overflow-hidden">
           {/* PDF Header */}
-          <div className="bg-dark-lighter text-white p-8 text-center">
-            <h1 className="text-3xl font-bold mb-2">
-              Enchanted Forest Adventure
-            </h1>
-            <p className="text-gray-400">Storyboard Presentation</p>
-            <div className="mt-4 text-sm text-gray-500">
-              Generated on {new Date().toLocaleDateString()}
-            </div>
+          <div className="bg-dark-lighter text-white p-8 text-center space-y-4">
+            <h1 className="text-3xl font-bold">Storyboard Presentation</h1>
+            <textarea
+              className="w-full bg-dark-card border border-gray-600 rounded p-2 text-sm text-white"
+              placeholder="Remarks"
+              value={remarks}
+              onChange={(e) => setRemarks(e.target.value)}
+            />
           </div>
 
           {/* PDF Content */}


### PR DESCRIPTION
## Summary
- add a custom dialog for replacing scene images
- update PDF preview header and add editable remarks field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869a42bc0908329988f82cc8ae11e41