### PR TITLE
Improve PDF export and update title

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -3,4 +3,6 @@ import { createServer } from "../server";
 
 const app = createServer();
 
-export default serverless(app);
+const handler = serverless(app, { binary: ["application/pdf"] });
+
+export default handler;

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -85,7 +85,10 @@ export async function deleteScene(id: number): Promise<void> {
   }
 }
 
-export async function downloadPdf(scenes: Scene[]): Promise<Blob> {
+export async function downloadPdf(
+  scenes: Scene[],
+  remarks?: string,
+): Promise<Blob> {
   try {
 
     const res = await fetch("/api/pdf", {
@@ -94,7 +97,7 @@ export async function downloadPdf(scenes: Scene[]): Promise<Blob> {
         "Content-Type": "application/json",
         Accept: "application/pdf",
       },
-      body: JSON.stringify({ scenes }),
+      body: JSON.stringify({ scenes, remarks }),
     });
     if (!res.ok) throw new Error("Failed to generate pdf");
 

--- a/client/pages/PDFPreview.tsx
+++ b/client/pages/PDFPreview.tsx
@@ -17,7 +17,7 @@ export default function PDFPreview() {
   const handleDownload = async () => {
     setIsDownloading(true);
     try {
-      const blob = await downloadPdf(scenes);
+      const blob = await downloadPdf(scenes, remarks);
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hello world project</title>
+    <title>StoryBoarding</title>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fusion-starter",
       "dependencies": {
         "express": "^4.18.2",
+        "node-fetch": "^3.3.2",
         "pdfkit": "^0.17.1",
         "serverless-http": "^3.2.0",
         "zod": "^3.23.8"
@@ -4845,6 +4846,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "3.6.0",
       "dev": true,
@@ -5290,6 +5300,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -5374,6 +5407,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6155,6 +6200,44 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -8353,6 +8436,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webgl-constants": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
+    "node-fetch": "^3.3.2",
     "pdfkit": "^0.17.1",
     "serverless-http": "^3.2.0",
     "zod": "^3.23.8"

--- a/server/routes/pdf.ts
+++ b/server/routes/pdf.ts
@@ -1,12 +1,14 @@
 import { RequestHandler } from "express";
 import PDFDocument from "pdfkit";
 import { Scene } from "@shared/api";
+import fetch from "node-fetch";
 
-export const generatePdf: RequestHandler = (req, res) => {
+export const generatePdf: RequestHandler = async (req, res) => {
   const scenes: Scene[] = Array.isArray(req.body?.scenes)
     ? req.body.scenes
     : [];
-  const doc = new PDFDocument();
+  const remarks: string = typeof req.body?.remarks === "string" ? req.body.remarks : "";
+  const doc = new PDFDocument({ autoFirstPage: false });
 
   res.status(200);
   res.setHeader("Content-Type", "application/pdf");
@@ -14,16 +16,47 @@ export const generatePdf: RequestHandler = (req, res) => {
 
   doc.pipe(res);
 
-  doc.fontSize(20).text("Storyboard", { align: "center" });
-  doc.moveDown();
-
-  scenes.forEach((scene, idx) => {
-    doc.fontSize(16).text(`${idx + 1}. ${scene.title}`);
-    doc.moveDown(0.5);
-    doc.fontSize(12).text(scene.details);
-    doc.moveDown(0.5);
-    doc.fontSize(10).text(scene.voiceover);
+  // Title page
+  doc.addPage();
+  doc.fontSize(26).text("Storyboard Presentation", { align: "center" });
+  if (remarks) {
     doc.moveDown();
+    doc.fontSize(12).text(remarks, { align: "center" });
+  }
+
+  for (const [idx, scene] of scenes.entries()) {
+    doc.addPage();
+    doc.fontSize(20).text(`${idx + 1}. ${scene.title}`);
+    doc.moveDown();
+
+    if (scene.image) {
+      try {
+        if (scene.image.startsWith("data:")) {
+          const base64 = scene.image.split(",", 2)[1];
+          const buffer = Buffer.from(base64, "base64");
+          doc.image(buffer, { fit: [500, 280], align: "center" });
+        } else {
+          const r = await fetch(scene.image);
+          const arr = await r.arrayBuffer();
+          doc.image(Buffer.from(arr), { fit: [500, 280], align: "center" });
+        }
+        doc.moveDown();
+      } catch {
+        // ignore image errors
+      }
+    }
+
+    doc.fontSize(12).text(scene.details);
+    doc.moveDown();
+    doc.fontSize(10).fillColor("gray").text(scene.voiceover, { oblique: true });
+    doc.fillColor("black");
+  }
+
+  doc.addPage();
+  doc.fontSize(12).text(`Total Scenes: ${scenes.length}`, { align: "center" });
+  doc.moveDown();
+  doc.fontSize(10).text("Designed with love by yantramayaa designs", {
+    align: "center",
   });
 
   doc.end();


### PR DESCRIPTION
## Summary
- update website title to **StoryBoarding**
- send remarks when generating PDFs
- handle binary PDFs on Vercel by enabling serverless-http binary mode
- enhance PDF generation to match preview layout and include images
- add `node-fetch` dependency for image downloads

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a8537c308329b07650ae9a453764