### PR TITLE
Fix PDF endpoint body size limit

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -14,8 +14,8 @@ export function createServer() {
 
   // Middleware
   app.use(cors());
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json({ limit: "10mb" }));
+  app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
   // Example API routes
   app.get("/api/ping", (_req, res) => {


### PR DESCRIPTION
## Summary
- allow larger request payload for PDF generation

## Testing
- `npm run build:server`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869aae403788329b290b9d5f34aff09