### PR TITLE
Add browser PDF generation

### DIFF
--- a/client/lib/localPdf.ts
+++ b/client/lib/localPdf.ts
@@ -1,0 +1,96 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { Scene } from '@shared/api';
+
+export async function generatePdfLocal(scenes: Scene[], remarks = ''): Promise<Blob> {
+  const pdfDoc = await PDFDocument.create();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  // Title Page
+  let page = pdfDoc.addPage();
+  const { height } = page.getSize();
+  page.drawText('Storyboard Presentation', {
+    x: 50,
+    y: height - 60,
+    size: 26,
+    font,
+    color: rgb(0, 0, 0),
+  });
+  if (remarks) {
+    page.drawText(remarks, {
+      x: 50,
+      y: height - 90,
+      size: 12,
+      font,
+    });
+  }
+
+  for (const [idx, scene] of scenes.entries()) {
+    page = pdfDoc.addPage();
+    const { height: h } = page.getSize();
+    page.drawText(`${idx + 1}. ${scene.title}`, {
+      x: 50,
+      y: h - 40,
+      size: 20,
+      font,
+    });
+
+    if (scene.image) {
+      try {
+        let imageBytes: Uint8Array | undefined;
+        if (scene.image.startsWith('data:')) {
+          const base64 = scene.image.split(',', 2)[1];
+          imageBytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+        } else {
+          const r = await fetch(scene.image);
+          const buf = await r.arrayBuffer();
+          imageBytes = new Uint8Array(buf);
+        }
+        if (imageBytes) {
+          const isPng = scene.image.startsWith('data:image/png') || scene.image.endsWith('.png');
+          const img = isPng
+            ? await pdfDoc.embedPng(imageBytes)
+            : await pdfDoc.embedJpg(imageBytes);
+          const dims = img.scaleToFit(500, 280);
+          page.drawImage(img, {
+            x: 50,
+            y: h - 80 - dims.height,
+            width: dims.width,
+            height: dims.height,
+          });
+        }
+      } catch {
+        // ignore image errors
+      }
+    }
+
+    page.drawText(scene.details, {
+      x: 50,
+      y: 80,
+      size: 12,
+      font,
+    });
+    page.drawText(scene.voiceover, {
+      x: 50,
+      y: 60,
+      size: 10,
+      font,
+    });
+  }
+
+  page = pdfDoc.addPage();
+  page.drawText(`Total Scenes: ${scenes.length}`, {
+    x: 50,
+    y: page.getHeight() - 60,
+    size: 12,
+    font,
+  });
+  page.drawText('Designed with love by yantramayaa designs', {
+    x: 50,
+    y: page.getHeight() - 80,
+    size: 10,
+    font,
+  });
+
+  const pdfBytes = await pdfDoc.save();
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}

--- a/client/pages/PDFPreview.tsx
+++ b/client/pages/PDFPreview.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Download, ArrowLeft, FileText } from "lucide-react";
 import { Scene } from "@shared/api";
-import { fetchScenes, downloadPdf } from "@/lib/api";
+import { fetchScenes } from "@/lib/api";
+import { generatePdfLocal } from "@/lib/localPdf";
 
 export default function PDFPreview() {
   const navigate = useNavigate();
@@ -17,7 +18,7 @@ export default function PDFPreview() {
   const handleDownload = async () => {
     setIsDownloading(true);
     try {
-      const blob = await downloadPdf(scenes, remarks);
+      const blob = await generatePdfLocal(scenes, remarks);
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "express": "^4.18.2",
         "node-fetch": "^3.3.2",
+        "pdf-lib": "^1.17.1",
         "pdfkit": "^0.17.1",
         "serverless-http": "^3.2.0",
         "zod": "^3.23.8"
@@ -709,6 +710,36 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@pdf-lib/upng/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6385,6 +6416,30 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pdfkit": {
       "version": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "node-fetch": "^3.3.2",
+    "pdf-lib": "^1.17.1",
     "pdfkit": "^0.17.1",
     "serverless-http": "^3.2.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary
- install `pdf-lib`
- add `generatePdfLocal` util for client side PDF creation
- use `generatePdfLocal` in the PDF preview page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869ad1cf464832994bb7ac40417afcd